### PR TITLE
Fix XSS in /respond.php

### DIFF
--- a/static/upload.php
+++ b/static/upload.php
@@ -155,6 +155,7 @@ function respond_csv ($code, $files) {
  * Responds to a request in JSON form.
  */
 function respond_json ($code, $files) {
+	header("Content-Type: application/json");
 	// Now we send the response based on the type
 	if ($files instanceof Exception) {
 		// If it's an Exception, we put the message in the error field


### PR DESCRIPTION
Tripped over this one. By no means even slightly a complete pentest. Had a little look over your code, your url generating code is strange; URL shortening algorithms work by mapping large indexes to short strings, a more correct algorithm is to map your number onto a high base dictated by the set of acceptable characters. Here is an implementation in PHP:


```PHP
<?PHP
$d = 'abcdefghijklmnopqrtsuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~';
$dl = strlen($d);

function short($i) {
	global $d, $dl;
	if ($i == 0) return $d[0];
	
	$out = "";
	while($i != 0) {
		$rem = $i % $dl;
		$i = floor($i / $dl);
		$out .= $d[$rem];
	}
	return $out;
}

function unshort($s) {
	global $d, $dl;
	$o = 0;
	foreach (str_split($s) as $pos => $ch) {
		$o += strpos($d, $ch) * pow($dl, $pos);
	}
	return $o;
}

```
1538 → Mu
Mu → 1358
