### PR TITLE
Fix duplicate filename check

### DIFF
--- a/static/upload.php
+++ b/static/upload.php
@@ -51,7 +51,7 @@ function generate_name ($file) {
 			$name .= '.' . strip_tags($ext);
 
 		// Check if a file with the same name does already exist in the database
-		$q = $db->prepare('SELECT COUNT(name) FROM pomf WHERE name = (:name)');
+		$q = $db->prepare('SELECT COUNT(filename) FROM files WHERE filename = (:name)');
 		$q->bindValue(':name', $name, PDO::PARAM_STR);
 		$q->execute();
 		$result = $q->fetchColumn();


### PR DESCRIPTION
pomf is the database, not the table. name is also non-existent. it
should be filename.